### PR TITLE
adding Maysora/lita-exclusive-route functionality

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,24 +1,32 @@
 PATH
   remote: .
   specs:
-    lita-clever (0.0.1)
+    lita-clever (0.0.2)
+      clever-api (>= 0.0.2)
       lita (>= 2.0)
+      lita-exclusive-route
 
 GEM
   remote: https://rubygems.org/
   specs:
+    clever-api (0.0.2)
+      rest-client
     diff-lcs (1.2.5)
-    faraday (0.9.1)
+    domain_name (0.5.25)
+      unf (>= 0.0.5, < 1.0.0)
+    faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    http_router (0.11.1)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
+    http_router (0.11.2)
       rack (>= 1.0.0)
       url_mount (~> 0.2.1)
     i18n (0.7.0)
     ice_nine (0.11.1)
-    lita (4.2.0)
+    lita (4.6.1)
       bundler (>= 1.3)
       faraday (>= 0.8.7)
-      http_router (>= 0.11.1)
+      http_router (>= 0.11.2)
       i18n (>= 0.6.9)
       ice_nine (>= 0.11.0)
       multi_json (>= 1.7.7)
@@ -27,15 +35,22 @@ GEM
       rb-readline (>= 0.5.1)
       redis-namespace (>= 1.3.0)
       thor (>= 0.18.1)
-    multi_json (1.10.1)
+    lita-exclusive-route (0.0.1)
+      lita (>= 3.3)
+    mime-types (2.6.2)
+    multi_json (1.11.2)
     multipart-post (2.0.0)
-    puma (2.11.1)
-      rack (>= 1.1, < 2.0)
-    rack (1.6.0)
-    rb-readline (0.5.2)
+    netrc (0.11.0)
+    puma (2.15.3)
+    rack (1.6.4)
+    rb-readline (0.5.3)
     redis (3.2.1)
-    redis-namespace (1.5.1)
+    redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     rspec (3.2.0)
       rspec-core (~> 3.2.0)
       rspec-expectations (~> 3.2.0)
@@ -50,6 +65,9 @@ GEM
       rspec-support (~> 3.2.0)
     rspec-support (3.2.1)
     thor (0.19.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
     url_mount (0.2.1)
       rack
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lita-clever (0.0.2)
+    lita-clever (0.0.3)
       clever-api (>= 0.0.2)
       lita (>= 2.0)
       lita-exclusive-route

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ No Configuration.
 ## Usage
 
 ```
-Lita: lita clever hello
+Lita: lita hello
 > Hello
 ```
 

--- a/lib/lita/handlers/clever.rb
+++ b/lib/lita/handlers/clever.rb
@@ -4,9 +4,7 @@ require 'clever-api'
 module Lita
   module Handlers
     class Clever < Handler
-      route(%r{^clever ([\w .-_]+)$}i, :clever, command: true, help: {
-        'clever' => 'Initializes clever.'
-      })
+      route %r{^(.+)$}, :clever, command: true, exclusive: true
 
       def self.default_config(handler_config)
       end

--- a/lita-clever.gemspec
+++ b/lita-clever.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'lita-clever'
-  spec.version       = '0.0.2'
+  spec.version       = '0.0.3'
   spec.authors       = ['Francis Hinson']
   spec.email         = ['francis@chesscademy.com']
   spec.description   = %q{A Lita handler for Cleverbot.}
@@ -19,4 +19,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.8'
   spec.add_development_dependency 'rspec', '~> 3.2.0'
+
+  spec.add_runtime_dependency "lita-exclusive-route"
 end

--- a/spec/lita/handlers/clever_spec.rb
+++ b/spec/lita/handlers/clever_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Lita::Handlers::Clever, lita_handler: true do
-  it {is_expected.to route_command("test").to(:test) }
+  it {is_expected.to route_command("test").to(:clever) }
 
   describe 'test' do
     it "replies to a 'test' command" do


### PR DESCRIPTION
I decided to remove the `clever` trigger to make conversing with Lita more natural.  @Maysora wrote lita-exclusive-route which works well here and props to him for sharing it.  It acts as a default route when text doesn't match an existing command.
